### PR TITLE
Feat: remove unnecessary fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ __pycache__/
 *.pyc
 .env
 *.env
+.idea
+.python-version
 __SUCCESS__

--- a/prv_candidates_step/core/strategy/utils/ztf_prv_detections_parser.py
+++ b/prv_candidates_step/core/strategy/utils/ztf_prv_detections_parser.py
@@ -41,7 +41,6 @@ class ZTFPreviousDetectionsParser(SurveyParser):
         prv_content["aid"] = aid
         prv_content["mjd"] = prv_content["mjd"] - 2400000.5
         prv_content["isdiffpos"] = 1 if prv_content["isdiffpos"] in ["t", "1"] else -1
-        prv_content["extra_fields"]["rfid"] = prv_content["rfid"]
         prv_content["extra_fields"]["rb"] = prv_content["rb"]
         prv_content["extra_fields"]["rbversion"] = prv_content["rbversion"]
         prv_content["extra_fields"]["parent_candid"] = parent_candid

--- a/prv_candidates_step/core/strategy/utils/ztf_prv_detections_parser.py
+++ b/prv_candidates_step/core/strategy/utils/ztf_prv_detections_parser.py
@@ -41,7 +41,7 @@ class ZTFPreviousDetectionsParser(SurveyParser):
         prv_content["aid"] = aid
         prv_content["mjd"] = prv_content["mjd"] - 2400000.5
         prv_content["isdiffpos"] = 1 if prv_content["isdiffpos"] in ["t", "1"] else -1
-        prv_content["parent_candid"] = parent_candid
+        prv_content["extra_fields"]["parent_candid"] = parent_candid
         e_radec = cls._celestial_errors[prv_content["fid"]]
         prv_content["e_ra"] = (
             prv_content["sigmara"] if "sigmara" in prv_content else e_radec

--- a/prv_candidates_step/core/strategy/utils/ztf_prv_detections_parser.py
+++ b/prv_candidates_step/core/strategy/utils/ztf_prv_detections_parser.py
@@ -41,6 +41,9 @@ class ZTFPreviousDetectionsParser(SurveyParser):
         prv_content["aid"] = aid
         prv_content["mjd"] = prv_content["mjd"] - 2400000.5
         prv_content["isdiffpos"] = 1 if prv_content["isdiffpos"] in ["t", "1"] else -1
+        prv_content["extra_fields"]["rfid"] = prv_content["rfid"]
+        prv_content["extra_fields"]["rb"] = prv_content["rb"]
+        prv_content["extra_fields"]["rbversion"] = prv_content["rbversion"]
         prv_content["extra_fields"]["parent_candid"] = parent_candid
         e_radec = cls._celestial_errors[prv_content["fid"]]
         prv_content["e_ra"] = (

--- a/prv_candidates_step/step.py
+++ b/prv_candidates_step/step.py
@@ -47,10 +47,18 @@ class PrvCandidatesStep(GenericStep):
             parsed_prv_detections = ztf_prv_detections_parser.parse(
                 result[1][index], alert["oid"], alert["aid"], alert["candid"]
             )
+            parsed_prv_detections = [
+                remove_keys_from_dictionary(
+                    prv, ["stamps", "rfid", "rb", "rbversion", "pid"]
+                )
+                for prv in parsed_prv_detections
+            ]
             parsed_non_detections = ztf_non_detections_parser.parse(
                 result[2][index], alert["aid"], alert["tid"], alert["oid"]
             )
-            stampless_alert = remove_keys_from_dictionary(alert, ["stamps", "rfid", "rb", "rbversion", "pid"])
+            stampless_alert = remove_keys_from_dictionary(
+                alert, ["stamps", "rfid", "rb", "rbversion", "pid"]
+            )
             stampless_alert["extra_fields"] = remove_keys_from_dictionary(
                 stampless_alert["extra_fields"], ["prv_candidates"]
             )

--- a/prv_candidates_step/step.py
+++ b/prv_candidates_step/step.py
@@ -1,15 +1,16 @@
-from typing import List
-from apf.core.step import GenericStep
-from prv_candidates_step.core.candidates.process_prv_candidates import (
-    process_prv_candidates,
-)
-from prv_candidates_step.core.utils.remove_keys import remove_keys_from_dictionary
-from prv_candidates_step.core.strategy.ztf_strategy import ZTFPrvCandidatesStrategy
-from prv_candidates_step.core.processor.processor import Processor
-from prv_candidates_step.core import ZTFPreviousDetectionsParser, ZTFNonDetectionsParser
-import logging
 import json
+import logging
+import uuid
+from typing import List
+
 from apf.core import get_class
+from apf.core.step import GenericStep
+
+from .core.candidates.process_prv_candidates import process_prv_candidates
+from .core.utils.remove_keys import remove_keys_from_dictionary
+from .core.strategy.ztf_strategy import ZTFPrvCandidatesStrategy
+from .core.processor.processor import Processor
+from .core import ZTFPreviousDetectionsParser, ZTFNonDetectionsParser
 
 
 class PrvCandidatesStep(GenericStep):
@@ -98,4 +99,9 @@ class PrvCandidatesStep(GenericStep):
 
     @staticmethod
     def _generate_id(non_detection):
-        return hash((non_detection["oid"], non_detection["fid"], non_detection["mjd"]))
+        keys = ["oid", "fid", "mjd"]
+
+        source = {k: v for k, v in non_detection.items() if k in keys}
+        assert all(k in keys for k in source)
+
+        return uuid.uuid5(uuid.NAMESPACE_URL, json.dumps(source)).hex

--- a/prv_candidates_step/step.py
+++ b/prv_candidates_step/step.py
@@ -50,7 +50,7 @@ class PrvCandidatesStep(GenericStep):
             parsed_non_detections = ztf_non_detections_parser.parse(
                 result[2][index], alert["aid"], alert["tid"], alert["oid"]
             )
-            stampless_alert = remove_keys_from_dictionary(alert, ["stamps"])
+            stampless_alert = remove_keys_from_dictionary(alert, ["stamps", "rfid", "rb", "rbversion", "pid"])
             stampless_alert["extra_fields"] = remove_keys_from_dictionary(
                 stampless_alert["extra_fields"], ["prv_candidates"]
             )

--- a/prv_candidates_step/step.py
+++ b/prv_candidates_step/step.py
@@ -54,9 +54,7 @@ class PrvCandidatesStep(GenericStep):
                 prv_detections[index], alert["oid"], alert["aid"], alert["candid"]
             )
             parsed_prv_detections = [
-                remove_keys_from_dictionary(
-                    prv, ["stamps", "rfid", "rb", "rbversion"]
-                )
+                remove_keys_from_dictionary(prv, ["stamps", "rfid", "rb", "rbversion"])
                 for prv in parsed_prv_detections
             ]
             parsed_non_detections = ztf_non_detections_parser.parse(

--- a/prv_candidates_step/step.py
+++ b/prv_candidates_step/step.py
@@ -61,6 +61,10 @@ class PrvCandidatesStep(GenericStep):
             parsed_non_detections = ztf_non_detections_parser.parse(
                 non_detections[index], alert["aid"], alert["tid"], alert["oid"]
             )
+            # move fields to extra_fields before removing them
+            alert["extra_fields"]["rfid"] = alert["rfid"]
+            alert["extra_fields"]["rb"] = alert["rb"]
+            alert["extra_fields"]["rbversion"] = alert["rbversion"]
             stampless_alert = remove_keys_from_dictionary(
                 alert, ["stamps", "rfid", "rb", "rbversion"]
             )

--- a/prv_candidates_step/step.py
+++ b/prv_candidates_step/step.py
@@ -49,7 +49,7 @@ class PrvCandidatesStep(GenericStep):
             )
             parsed_prv_detections = [
                 remove_keys_from_dictionary(
-                    prv, ["stamps", "rfid", "rb", "rbversion", "pid"]
+                    prv, ["stamps", "rfid", "rb", "rbversion"]
                 )
                 for prv in parsed_prv_detections
             ]
@@ -57,7 +57,7 @@ class PrvCandidatesStep(GenericStep):
                 result[2][index], alert["aid"], alert["tid"], alert["oid"]
             )
             stampless_alert = remove_keys_from_dictionary(
-                alert, ["stamps", "rfid", "rb", "rbversion", "pid"]
+                alert, ["stamps", "rfid", "rb", "rbversion"]
             )
             stampless_alert["extra_fields"] = remove_keys_from_dictionary(
                 stampless_alert["extra_fields"], ["prv_candidates"]

--- a/prv_candidates_step/step.py
+++ b/prv_candidates_step/step.py
@@ -55,7 +55,7 @@ class PrvCandidatesStep(GenericStep):
                 prv_detections[index], alert["oid"], alert["aid"], alert["candid"]
             )
             parsed_prv_detections = [
-                remove_keys_from_dictionary(prv, ["stamps", "rfid", "rb", "rbversion"])
+                remove_keys_from_dictionary(prv, ["stamps", "rb", "rbversion"])
                 for prv in parsed_prv_detections
             ]
             parsed_non_detections = ztf_non_detections_parser.parse(

--- a/schema.avsc
+++ b/schema.avsc
@@ -46,24 +46,12 @@
             "type": "double"
           },
           {
-            "name": "rb",
-            "type": ["null", "float"]
-          },
-          {
-            "name": "rbversion",
-            "type": ["null", "string"]
-          },
-          {
             "name": "mag",
             "type": "float"
           },
           {
             "name": "e_mag",
             "type": "float"
-          },
-          {
-            "name": "rfid",
-            "type": ["null", "int"]
           },
           {
             "name": "isdiffpos",

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -16,7 +16,7 @@ def test_prv_detections_parser():
     result = parser.parse(data, "oid", "aid", "parent_candid")
     assert result[0]["aid"] == "aid"
     assert result[0]["oid"] == "oid"
-    assert result[0]["parent_candid"] == "parent_candid"
+    assert result[0]["extra_fields"]["parent_candid"] == "parent_candid"
 
 
 def test_non_detections_parser():

--- a/tests/unit/test_scribe.py
+++ b/tests/unit/test_scribe.py
@@ -19,11 +19,11 @@ def test_produce_scribe(env_variables):
     }
     non_detections = [non_detection]
     step.scribe_producer = MagicMock(KafkaProducer)
-    step.produce_scribe(non_detections, "candid")
+    step.produce_scribe(non_detections)
     expected_data = {
         "collection": "non_detection",
         "type": "update",
-        "criteria": {"_id": "candid"},
+        "criteria": {"_id": step._generate_id(non_detection)},
         "data": non_detection,
         "options": {"upsert": True},
     }
@@ -47,11 +47,11 @@ def test_post_execute(env_variables):
     }
     non_detections = [non_detection]
     step.scribe_producer = MagicMock(KafkaProducer)
-    step.post_execute([{"aid": "aid", "new_alert": {"candid": "candid"}, "non_detections": non_detections}])
+    step.post_execute([{"aid": "aid", "non_detections": non_detections}])
     expected_data = {
         "collection": "non_detection",
         "type": "update",
-        "criteria": {"_id": "candid"},
+        "criteria": {"_id": step._generate_id(non_detection)},
         "data": non_detection,
         "options": {"upsert": True},
     }

--- a/tests/unit/test_scribe.py
+++ b/tests/unit/test_scribe.py
@@ -47,7 +47,7 @@ def test_post_execute(env_variables):
     }
     non_detections = [non_detection]
     step.scribe_producer = MagicMock(KafkaProducer)
-    step.post_execute(([{"aid": "aid", "candid": "candid"}], [], [non_detections]))
+    step.post_execute([{"aid": "aid", "new_alert": {"candid": "candid"}, "non_detections": non_detections}])
     expected_data = {
         "collection": "non_detection",
         "type": "update",


### PR DESCRIPTION
Removes fields not expected in correction step.

In the scribe, the `_id` for non detections now uses a hash created from `oid`, `fid` and `mjd`.

**Additional fix:** Fields written using scribe were wrong, it was passing the raw non detections. The origin has to do with the order of new functions: `pre_produce` is executed *after* `post_execute`, so the cleaned up fields were not there when producing to scribe.